### PR TITLE
Count redis round trips not calls

### DIFF
--- a/lib/time_bandits/time_consumers/redis.rb
+++ b/lib/time_bandits/time_consumers/redis.rb
@@ -16,7 +16,7 @@ module TimeBandits
         def request(event)
           i = Redis.instance
           i.time += event.duration
-          i.calls += event.payload[:commands].size
+          i.calls += 1 #count redis round trips, not calls
 
           return unless logger.debug?
 


### PR DESCRIPTION
When using `Redis::Client#pipelined` or `Redis::Client#multi` commands are queued and send in a single batch to Redis. Counting the commands in the batch seems to be misleading in that case (at least I was confused ^^). I think we should better count the round trips to redis instead of the calls. 
