### PR TITLE
measure time and calls with sequel

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -80,7 +80,7 @@ changed so much of the code that is is practically a full rewrite, hence we chan
 
 == Running Tests
 
-In order for the test to run you need a running memcached and redis-server
+In order for the test to run you need a running memcached, redis-server and mysql
 
 == Release Notes
 

--- a/lib/time_bandits.rb
+++ b/lib/time_bandits.rb
@@ -15,6 +15,7 @@ module TimeBandits
     autoload :Memcached,         'time_bandits/time_consumers/memcached'
     autoload :Dalli,             'time_bandits/time_consumers/dalli'
     autoload :Redis,             'time_bandits/time_consumers/redis'
+    autoload :Sequel,            'time_bandits/time_consumers/sequel'
   end
 
   require 'time_bandits/railtie' if defined?(Rails) && Rails::VERSION::STRING >= "3.0"
@@ -44,8 +45,12 @@ module TimeBandits
   end
 
   def self.metrics
-    metrics = {}
-    time_bandits.each{|b| metrics.merge! b.metrics}
+    metrics = Hash.new(0)
+    time_bandits.each do |bandit|
+      bandit.metrics.each do |k,v|
+        metrics[k] += v
+      end
+    end
     metrics
   end
 

--- a/lib/time_bandits/monkey_patches/sequel.rb
+++ b/lib/time_bandits/monkey_patches/sequel.rb
@@ -1,0 +1,18 @@
+require 'sequel'
+
+major, minor, patch = Sequel.version.split('.').map(&:to_i)
+raise "time_bandits Sequel monkey patch is not compatible with your sequel version" if
+  major < 4 || (major == 4 && minor < 15)
+
+Sequel::Database.class_eval do
+  alias :_orig_log_yield :log_yield
+
+  def log_yield(*args)
+    begin
+      start = Time.now
+      _orig_log_yield(args) { yield if block_given? }
+    ensure
+      ActiveSupport::Notifications.instrument('duration.sequel', durationInSeconds: Time.now - start)
+    end
+  end
+end

--- a/lib/time_bandits/time_consumers/sequel.rb
+++ b/lib/time_bandits/time_consumers/sequel.rb
@@ -1,0 +1,25 @@
+# a time consumer implementation for sequel
+# install into application_controller.rb with the line
+#
+#   time_bandit TimeBandits::TimeConsumers::Sequel
+#
+require 'time_bandits/monkey_patches/sequel'
+
+module TimeBandits
+  module TimeConsumers
+    class Sequel < BaseConsumer
+      prefix :db
+      fields :time, :calls
+      format "Sequel: %.3fms(%dq)", :time, :calls
+
+      class Subscriber < ActiveSupport::LogSubscriber
+        def duration(event)
+          i = Sequel.instance
+          i.time  += (event.payload[:durationInSeconds] * 1000)
+          i.calls += 1
+        end
+      end
+      Subscriber.attach_to(:sequel)
+    end
+  end
+end

--- a/test/unit/duplicate_bandits.rb
+++ b/test/unit/duplicate_bandits.rb
@@ -1,0 +1,58 @@
+require_relative '../test_helper'
+
+class DuplicateBandits < Test::Unit::TestCase
+  class FooConsumer < TimeBandits::TimeConsumers::BaseConsumer
+    prefix :simple
+    fields :time, :calls
+    format "SimpleFoo: %.1fms(%d calls)", :time, :calls
+  end
+
+  class BarConsumer < TimeBandits::TimeConsumers::BaseConsumer
+    prefix :simple
+    fields :time, :calls
+    format "SimpleBar: %.1fms(%d calls)", :time, :calls
+  end
+
+  def setup
+    TimeBandits.time_bandits = []
+    TimeBandits.add FooConsumer
+    TimeBandits.add BarConsumer
+    TimeBandits.reset
+  end
+
+  test "nothing measured" do
+    assert_equal({
+      :simple_time => 0,
+      :simple_calls => 0
+    }, TimeBandits.metrics)
+  end
+
+  test "only one consumer measured sth (the one)" do
+    FooConsumer.instance.calls = 3
+    FooConsumer.instance.time  = 0.123
+    assert_equal({
+      :simple_time => 0.123,
+      :simple_calls => 3
+    }, TimeBandits.metrics)
+  end
+
+  test "only one consumer measured sth (the other)" do
+    BarConsumer.instance.calls = 2
+    BarConsumer.instance.time  = 0.321
+    assert_equal({
+      :simple_time => 0.321,
+      :simple_calls => 2
+    }, TimeBandits.metrics)
+  end
+
+  test "both consumer measured sth" do
+    FooConsumer.instance.calls = 3
+    FooConsumer.instance.time  = 0.123
+    BarConsumer.instance.calls = 2
+    BarConsumer.instance.time  = 0.321
+    assert_equal({
+      :simple_time => 0.444,
+      :simple_calls => 5
+    }, TimeBandits.metrics)
+  end
+end

--- a/test/unit/sequel_test.rb
+++ b/test/unit/sequel_test.rb
@@ -1,0 +1,43 @@
+require_relative '../test_helper'
+require 'sequel'
+
+class SequelTest < Test::Unit::TestCase
+  def setup
+    TimeBandits.time_bandits = []
+    TimeBandits.add TimeBandits::TimeConsumers::Sequel
+    TimeBandits.reset
+  end
+
+  test "getting metrics" do
+    nothing_measured = {
+      :db_time => 0,
+      :db_calls => 0
+    }
+    assert_equal nothing_measured, metrics
+  end
+
+  test "formatting" do
+    bandit.calls = 3
+    assert_equal "Sequel: 0.000ms(3q)", TimeBandits.runtime
+  end
+
+  test "metrics" do
+    (1..4).each { sequel['SELECT 1'].all }
+
+    assert_equal 6, metrics[:db_calls] # +2 for set wait_timeout and set SQL_AUTO_IS_NULL=0
+    assert 0 < metrics[:db_time]
+    assert_equal metrics[:db_time], TimeBandits.consumed
+  end
+
+  def sequel
+    @sequel ||= Sequel.connect('mysql2://localhost:3601')
+  end
+
+  def metrics
+    TimeBandits.metrics
+  end
+
+  def bandit
+    TimeBandits::TimeConsumers::Sequel.instance
+  end
+end

--- a/time_bandits.gemspec
+++ b/time_bandits.gemspec
@@ -26,6 +26,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency("dalli")
   s.add_development_dependency("redis")
   s.add_development_dependency("memcached")
+  s.add_development_dependency("sequel")
+  s.add_development_dependency("mysql2")
   s.add_development_dependency("minitest", '~> 4.7.5')
 end
 


### PR DESCRIPTION
I've ran that code in one project (not on production yet) with both, ActiveRecord and Sequel, enabled. Seems to work fine:
`Completed 200 OK in 281.4ms (Views: 0.522ms | ActiveRecord: 5.551ms(1q,0h) | REST: 263.257(3, 3) | Sequel: 0.681ms(1q) | GC: 0.982(0) | HP: 0(999600,6023,157952,426406))`
