### PR TITLE
Multiply 1000 to get the actual millisecond for completed time

### DIFF
--- a/lib/time_bandits/rack/logger40.rb
+++ b/lib/time_bandits/rack/logger40.rb
@@ -36,7 +36,7 @@ module TimeBandits
         finish(request)
         raise
       ensure
-        completed(request, Time.now - start_time, resp)
+        completed(request, (Time.now - start_time) * 1000, resp)
         ActiveSupport::LogSubscriber.flush_all!
       end
 


### PR DESCRIPTION
The diff of time objects is in second (a float number).

http://stackoverflow.com/questions/1414951/how-do-i-get-elapsed-time-in-milliseconds-in-ruby

Multiplying 1000 to get the actual millisecond diff.

Resolve #8 
