### PR TITLE
Call type_casted_binds with only one argument in Rails 5.0.7

### DIFF
--- a/lib/time_bandits/monkey_patches/active_record.rb
+++ b/lib/time_bandits/monkey_patches/active_record.rb
@@ -103,6 +103,24 @@ module ActiveRecord
 
         debug "  #{name}  #{sql}#{binds}"
       end
+    elsif Rails::VERSION::STRING == "5.0.7"
+      def log_sql_statement(payload, event)
+        name = '%s (%.1fms)' % [payload[:name], event.duration]
+        sql  = payload[:sql].squeeze(' ')
+        binds = nil
+
+        unless (payload[:binds] || []).empty?
+          casted_params = type_casted_binds(payload[:type_casted_binds])
+          binds = "  " + payload[:binds].zip(casted_params).map { |attr, value|
+            render_bind(attr, value)
+          }.inspect
+        end
+
+        name = colorize_payload_name(name, payload[:name])
+        sql  = color(sql, sql_color(sql), true)
+
+        debug "  #{name}  #{sql}#{binds}"
+      end
     elsif Rails::VERSION::STRING >= "5.0.3"
       def log_sql_statement(payload, event)
         name = '%s (%.1fms)' % [payload[:name], event.duration]


### PR DESCRIPTION
This change adds a special case to the conditional in which `log_sql_statement` is defined/overwritten  for `Rails 5.0.7` which will be handled like other Rails versions `>= "5.0.3"`, with the only change to call `type_casted_binds(payload[:type_casted_binds])` (without the `payload[:binds]` argument).

* the changes to the private AR method `type_casted_binds` have been backported to Rails 5.0.7
* https://github.com/rails/rails/commit/abbc8351cd19f676476242bd6a0836b83dc3f0f0