### PR TITLE
Replace deprecated to_default_s on start_time with to_s

### DIFF
--- a/lib/time_bandits/rack/logger.rb
+++ b/lib/time_bandits/rack/logger.rb
@@ -12,6 +12,7 @@ module TimeBandits
         @app          = app
         @taggers      = taggers || Rails.application.config.log_tags || []
         @instrumenter = ActiveSupport::Notifications.instrumenter
+        @use_to_default_s = Gem::Version.new(Rails::VERSION::STRING) < Gem::Version.new("7.1.0")
       end
 
       def call(env)
@@ -43,11 +44,12 @@ module TimeBandits
 
       # Started GET "/session/new" for 127.0.0.1 at 2012-09-26 14:51:42 -0700
       def started_request_message(request, start_time = Time.now)
+        start_time_str = @use_to_default_s ? start_time.to_default_s : start_time.to_s
         'Started %s "%s" for %s at %s' % [
           request.request_method,
           request.filtered_path,
           request.ip,
-          start_time.to_s ]
+          start_time_str ]
       end
 
       def compute_tags(request)

--- a/lib/time_bandits/rack/logger.rb
+++ b/lib/time_bandits/rack/logger.rb
@@ -47,7 +47,7 @@ module TimeBandits
           request.request_method,
           request.filtered_path,
           request.ip,
-          start_time.to_default_s ]
+          start_time.to_s ]
       end
 
       def compute_tags(request)


### PR DESCRIPTION
The method `to_default_s` got deprecated and is no longer existent since version `6.1.7.7` of ActiveSupport. In previous versions, e.g. `5.0.7.2` it was already an alias for `to_s`.

See also https://apidock.com/rails/ActiveSupport/RangeWithFormat/to_default_s